### PR TITLE
Fix: Correct sequence and structure inpainting logic

### DIFF
--- a/aa_model.py
+++ b/aa_model.py
@@ -303,8 +303,11 @@ class Model:
         o.terminus_type[n_prot-1] = C_TERMINUS
 
         is_diffused_prot = ~torch.from_numpy(contig_map.inpaint_str)
+        is_seq_masked_prot = ~torch.from_numpy(contig_map.inpaint_seq)
         is_diffused_sm = torch.zeros(n_sm).bool()
+        is_seq_masked_sm = torch.zeros(n_sm).bool()
         is_diffused = torch.cat((is_diffused_prot, is_diffused_sm))
+        is_seq_masked = torch.cat((is_seq_masked_prot, is_seq_masked_sm))
         is_atom_str_shown = contig_map.atomize_indices2atomname
         # The motifs for atomization are double-counted.
         if is_atom_str_shown:
@@ -318,7 +321,7 @@ class Model:
         o.xyz[o.is_sm,:3] = sm_ca[...,None,:]
         o.xyz[o.is_sm] += chemical.INIT_CRDS
 
-        return o, is_diffused, is_diffused
+        return o, is_diffused, is_seq_masked
 
 
     def prepro(self, indep, t, is_diffused):


### PR DESCRIPTION
The `insert_contig` method in `aa_model.py` was incorrectly using the structure inpainting flag (`inpaint_str`) to determine if a sequence should be masked. This led to two erroneous behaviors:
1. If `inpaint_seq` was set (to mask sequence) but `inpaint_str` was not, the sequence was not masked.
2. If `inpaint_str` was set (to diffuse structure) but `inpaint_seq` was not, the sequence was unexpectedly masked.

This commit corrects the logic by:
- Introducing `is_seq_masked_prot` and `is_seq_masked_sm` derived from `contig_map.inpaint_seq`.
- Returning the correctly derived `is_seq_masked` instead of returning `is_diffused` twice.

This change ensures that `inpaint_seq` correctly controls sequence masking and `inpaint_str` correctly controls structure diffusion, independently of each other.